### PR TITLE
[Fix] Configuração de volume persistente para dados do sistema

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -21,3 +21,7 @@ primary_region = 'gru'
   cpu_kind = 'shared'
   cpus = 1
   memory_mb = 1024
+
+[mounts]
+source = "mf_data"
+destination = "/app/src/data"

--- a/src/server.js
+++ b/src/server.js
@@ -4,9 +4,12 @@ const path = require('path');
 const fs = require('fs');
 const apiRoutes = require('./routes/api');
 const equipamentosRoutes = require('./routes/equipamentos');
+const { initData } = require('./utils/initData');
 
 const app = express();
 const PORT = process.env.PORT || 3003;
+
+initData();
 
 // Ensure products image directory exists
 const produtosDir = path.join(__dirname, 'public', 'produtos');

--- a/src/utils/initData.js
+++ b/src/utils/initData.js
@@ -1,0 +1,35 @@
+﻿const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '../data');
+const ORDENS_DIR = path.join(DATA_DIR, 'ordens');
+
+const DEFAULTS = {
+    'equipamentos.json': {
+        proximo_id: 1,
+        equipamentos: []
+    },
+    'config-equipamentos.json': {
+        responsaveis_entrega: [],
+        responsaveis_equipamento: [],
+        locais_frequentes: [],
+        eventos_recentes: [],
+        proximo_numero: 1
+    }
+};
+
+function initData() {
+    if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+    if (!fs.existsSync(ORDENS_DIR)) fs.mkdirSync(ORDENS_DIR, { recursive: true });
+
+    // Só cria os JSONs base se não existirem (volume novo/vazio)
+    for (const [filename, defaultData] of Object.entries(DEFAULTS)) {
+        const filepath = path.join(DATA_DIR, filename);
+        if (!fs.existsSync(filepath)) {
+            fs.writeFileSync(filepath, JSON.stringify(defaultData, null, 2));
+            console.log(`[initData] Criado: ${filename}`);
+        }
+    }
+}
+
+module.exports = {initData};


### PR DESCRIPTION
## [Fix] Configuração de volume persistente para dados do sistema

**Ref:** #1

---

## Problema

Os flat-files em `src/data/` (equipamentos, configurações e ordens de
serviço) viviam dentro do filesystem efêmero do container. A cada novo
deploy no Fly.io, todo esse diretório era destruído — apagando
silenciosamente todas as Ordens de Serviço e o catálogo de equipamentos.

---

## Solução

- Adicionado bloco `[mounts]` no `fly.toml` apontando `mf_data` →
  `/app/src/data`, garantindo persistência entre deploys
- Criado `src/utils/initData.js`: script idempotente que cria as pastas
  e arquivos JSON base apenas quando o volume é montado vazio (primeiro
  deploy). Não sobrescreve dados existentes
- Integrado `initData()` no topo de `src/server.js`, antes de qualquer
  rota ou middleware

---

## Checklist

- [ ] `fly.toml` contém bloco `[mounts]` apontando para `/app/src/data`
- [ ] `src/utils/initData.js` criado e integrado ao `src/server.js`
- [ ] `initData()` é idempotente — silencioso quando arquivos já existem
- [ ] Antes do merge: executar `fly volumes create mf_data --region gru --size 1`
- [ ] Após deploy: `fly ssh console` confirma dados em `/app/src/data/`
- [ ] Após segundo deploy: dados persistem

---

Closes #1