### PR TITLE
[Fix] Bug de porta: internal_port 3003 → 8080

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,7 +9,7 @@ primary_region = 'gru'
 [build]
 
 [http_service]
-  internal_port = 3003
+  internal_port = 8080
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true


### PR DESCRIPTION
## [Fix] Bug de porta: internal_port 3003 → 8080

**Ref:** #3

---

## Problema

O `fly.toml` definia `internal_port = 3003`, mas o Fly.io injeta
`PORT=8080` em runtime. O Express escutava em `8080` mas o Fly
roteava para `3003` — onde nenhum processo estava escutando.

---

## Solução

- Alterado `internal_port` de `3003` para `8080` no `fly.toml`
- Confirmado que `src/server.js` usa `process.env.PORT || 3003`
  (8080 em produção, 3003 como fallback local)

---

## Checklist

- [x] `fly.toml` com `internal_port = 8080`
- [x] `src/server.js` usa `process.env.PORT || 3003`
- [x] Após deploy: `fly logs` não exibe erro de porta
- [x] Após deploy: aplicação responde em produção

---

Closes #3