### PR TITLE
[Feature] Cache persistente do catálogo com TTL de 60min e renovação automática

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -8,3 +8,5 @@
 /dataSources.local.xml
 # Editor-based HTTP Client requests
 /httpRequests/
+# Cache do catálogo de produtos (gerado em runtime, persiste no volume Fly.io)
+src/data/catalogo-cache.json

--- a/src/data/catalogo-cache.json
+++ b/src/data/catalogo-cache.json
@@ -1,0 +1,1631 @@
+{
+  "atualizadoEm": 1773472592020,
+  "produtos": [
+    {
+      "nome": "1 - Blue To Jllyfish / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1 - Blue To Jllyfish / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "1 - Brocade Coconut / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1 - Brocade Coconut / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "1 - Green Chrys / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1 - Green Chrys / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "1 - Red Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1 - Red To Brocade Ring / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1 - Red To Brocade Ring / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "1 - Red to white Strobe Mine",
+      "disponivel": true,
+      "quantidade": 29,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1 - Smoke Rosa 10/1 - 06 tubos [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 29,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1 - Smoke Rosa 10/1 - 06 tubos [ UNIDADE ]",
+      "disponivel": true,
+      "quantidade": 16,
+      "unidade": "Un"
+    },
+    {
+      "nome": "1 - Torta Malta / Gold Tail - Blue Tip",
+      "disponivel": true,
+      "quantidade": 307,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "1.1 - Torta Malta / Gold Tail - Pink Tip",
+      "disponivel": true,
+      "quantidade": 144,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "10 - Brocade Cracker Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "10 - Brocade Pink",
+      "disponivel": true,
+      "quantidade": 49,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "10 - Gold Time Rain / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "10 - Gold Time Rain / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "10 - Orange Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "10 - Orange Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "10 - Red Dark Time Rain / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "10 - Red Dark Time Rain / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "10 - Red To Brocade Chry With Red Strobe / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "10 - Red To Brocade Chry With Red Strobe / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "10 - Torta Malta / Gold Strobe Tail - Red Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "11 - Brocade Green Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "11 - Devil Ring Silver Strobe / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "11 - Devil Ring Silver Strobe / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "11 - Green To Crackling / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "11 - Green To Crackling / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "11 - Red Cracker",
+      "disponivel": true,
+      "quantidade": 35,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "11 - Red To Green To Blue / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "11 - Red To Green To Blue / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "11 - Torta Malta / Gold Strobe Tail - Purple Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "12 - Blue To Yellow Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "12 - Blue To Yellow Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "12 - Brocade Silver Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "12 - Crackling Iron Tree With Red Strobe Pistola With Tail / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "12 - Crackling Iron Tree With Red Strobe Pistola With Tail / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "12 - Green Cracker",
+      "disponivel": true,
+      "quantidade": 38,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "12 - Pink To Crackling / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "12 - Pink To Crackling / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "12 - Torta Malta / Silver Strobe Tail - Blue Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "13 - Blue Cracker",
+      "disponivel": true,
+      "quantidade": 37,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "13 - Blue Ring W/ Silver Ware Red Ring / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "13 - Blue Ring W/ Silver Ware Red Ring / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "13 - Gold Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "13 - Gold Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "13 - Purple Willow / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "13 - Purple Willow / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "13 - Red to Cracker",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "13 - Torta Malta / Silver Strobe Tail - Red Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "14 - Green Chys / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "14 - Green Chys / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "14 - Pink to Cracker",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "14 - Purple Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "14 - Purple Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "14 - Red Strobe Mine",
+      "disponivel": true,
+      "quantidade": 37,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "14 - Torta Malta / Silver Strobe Tail - Green Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "14 - Yellow Peony / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "14 - Yellow Peony / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "15 - Gold Glitter Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "15 - Green Peony / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 7,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "15 - Green Peony / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "15 - Lemon Dahlia / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "15 - Lemon Dahlia / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "15 - Purple To Silver Strobe / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "15 - Purple To Silver Strobe / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "15 - Red Strobe Tail + Blue Mine",
+      "disponivel": true,
+      "quantidade": 18,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "15 - Torta Malta / Silver Strobe Tail - Pink Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "16 - Flower Brocade To Purple / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 7,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "16 - Flower Brocade To Purple / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "16 - Red Glitter Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "16 - Red Mushroom / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 8,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "16 - Red Mushroom / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "16 - Red Tiger Tail + White Strobe Mine",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "16 - Torta Malta / Cracker Tail",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "16 - Yellow Blue Peony With Coco Pistil / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "16 - Yellow Blue Peony With Coco Pistil / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "17 - Brocade Tail Tô Brocade / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 8,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "17 - Brocade Tail Tô Brocade / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "17 - Green Chrys / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 9,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "17 - Green Chrys / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "17 - Green Glitter Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "17 - Green Tiger Tail + White Strobe Mine",
+      "disponivel": true,
+      "quantidade": 2,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "17 - Purple Orange Peony With Coco Pistil / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "17 - Purple Orange Peony With Coco Pistil / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "18 - Green Strobe Tail + Red Mine",
+      "disponivel": true,
+      "quantidade": 19,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "18 - Red To Small Chrys With Crackling Pistil / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "18 - Red To Small Chrys With Crackling Pistil / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "18 - Silver Tail Tô Silver Wave With Red Peony Pistel / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 14,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "18 - Silver Tail Tô Silver Wave With Red Peony Pistel / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "18 - Silver To Red Peony / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 9,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "18 - Silver To Red Peony / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "18 - White Glitter Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "19 - Brocade Tail To Brocade To Dragon Chrys / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "19 - Brocade Tail To Brocade To Dragon Chrys / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "19 - Cracker Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "19 - Purple Peony With Silver Palm Pistl / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 10,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "19 - Purple Peony With Silver Palm Pistl / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "19 - Silver Tiger Tail",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Blue Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Blue Mine withred Strobe",
+      "disponivel": true,
+      "quantidade": 40,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Blue Purple Yellow Green Peony / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Blue Purple Yellow Green Peony / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "2 - Flower Brocade To Yellow / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Flower Brocade To Yellow / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "2 - Green Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Green Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "2 - Silver Willow / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 2,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Silver Willow / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "2 - Smoke Azul 10/1 - 06 tubos  [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 33,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "2 - Smoke Azul 10/1 - 06 tubos  [ UNIDADE ]",
+      "disponivel": true,
+      "quantidade": 13,
+      "unidade": "Un"
+    },
+    {
+      "nome": "2 - Torta Malta / Gold Tail - Red Tip",
+      "disponivel": true,
+      "quantidade": 142,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "20 - Blue To Orange / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 14,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "20 - Blue To Orange / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "20 - Gold Tail",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "20 - Silver Strobe / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "20 - Silver Strobe / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "20 - Silver Tiger Tail + Red Strobe Mine",
+      "disponivel": true,
+      "quantidade": 9,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "21 - Gold Tail - Green Strobe Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "21 - Silver Strobo / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 15,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "21 - Silver Strobo / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "21 - Silver Tiger Tail + Red Mine",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "21 - Smile Face / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "21 - Smile Face / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "22 - Brocade To White Strobe / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "22 - Brocade To White Strobe / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "22 - Gold Tail - Red Strobe Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "22 - Orange Peony / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 17,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "22 - Orange Peony / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "22 - Silver Tiger Tail + Blue Mine",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "23 - Gold Tail - Blue Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "23 - Purple Tiger Tail + Green Strobe Mine",
+      "disponivel": true,
+      "quantidade": 33,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "23 - Red Peony / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 19,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "23 - Red Peony / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "23 - Silver To Color Crossete / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "23 - Silver To Color Crossete / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "24 - Blue Peony With Brocade Ring / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "24 - Blue Peony With Brocade Ring / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "24 - Gold Strobe Tail + Blue Mine",
+      "disponivel": true,
+      "quantidade": 7,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "24 - Gold Tail - Red Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "24 - Purple To Silver / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 20,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "24 - Purple To Silver / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "25 - Chry To Blue / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 8,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "25 - Chry To Blue / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "25 - Chrys To Purple / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 23,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "25 - Chrys To Purple / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "25 - Gold Strobe Tail + Green Strobe Mine",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "26 - Gold Palm Comet Tail + Green Strobe Mine",
+      "disponivel": true,
+      "quantidade": 9,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "26 - Purple Willow / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 9,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "26 - Purple Willow / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "27 - Gold Tail + Blue Mine",
+      "disponivel": true,
+      "quantidade": 15,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "27 - Red To Blue Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 9,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "27 - Red To Blue Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "28 - Crossete Red Tiger Tail",
+      "disponivel": true,
+      "quantidade": 24,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "28 - Red To Brocade / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 10,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "28 - Red To Brocade / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "29 - Brocade To Color / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 10,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "29 - Brocade To Color / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "29 - Crossete Pink Tiger Tail",
+      "disponivel": true,
+      "quantidade": 44,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "3 - Chry To Time Rain / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "3 - Chry To Time Rain / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "3 - Flower Brocade2 / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 2,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "3 - Flower Brocade2 / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "3 - Green Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "3 - Red Peony White Green Strobo Pistil / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "3 - Red Peony White Green Strobo Pistil / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "3 - Silver Palm Tree Red Strobe Pistil / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "3 - Silver Palm Tree Red Strobe Pistil / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "3 - Smoke Roxa 10/1 - 06 tubos [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 29,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "3 - Smoke Roxa 10/1 - 06 tubos [ UNIDADE ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Un"
+    },
+    {
+      "nome": "3 - Torta Malta / Gold Tail - Purple Tip",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "30 - Gold Tail  + Red Mine",
+      "disponivel": true,
+      "quantidade": 2,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "30 - Gold Willow To Blue / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 10,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "30 - Gold Willow To Blue / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "31 - Blue Tiger Tail",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "31 - Brocade Tail To Ti - Gold Palm Tree / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 10,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "31 - Brocade Tail To Ti - Gold Palm Tree / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "32 - Comet Cracker + Red Strobe Mine",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "32 - Green Wave / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 11,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "32 - Green Wave / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "33 - Layer White + Red Strobe Willow + Blue Mine",
+      "disponivel": true,
+      "quantidade": 44,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "33 - Yellow Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 10,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "33 - Yellow Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "34 - Crackling Crossete / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 11,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "34 - Crackling Crossete / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "34 - Layer Blue + Crackle Comet + Red Strobe Mine",
+      "disponivel": true,
+      "quantidade": 48,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "35 - Silver Wave To Red / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 12,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "35 - Silver Wave To Red / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "36 - Red Wave / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 17,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "36 - Red Wave / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "37 - Red Crys / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 13,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "37 - Red Crys / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "4 - Gold Crys / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - Gold Crys / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "4 - Pink Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - Purple Mine with Green Strobe",
+      "disponivel": true,
+      "quantidade": 36,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - Red To Blue Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - Red To Blue Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "4 - Smoke Rosa 4/1 - 25 tubos [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 36,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - Smoke Rosa 4/1 - 25 tubos [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "4 - Torta Malta / Gold Tail - Green Tip",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - White Strobe / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - White Strobe / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "4 - White Strobo / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "4 - White Strobo / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "5 - Blue to Red Strobe Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "5 - Red Peony To White Strobo Brocade / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "5 - Red Peony To White Strobo Brocade / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "5 - Silver Butterfly / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 2,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "5 - Silver Butterfly / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "5 - Silver Palm Tree Crackling Pistil / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 1,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "5 - Silver Palm Tree Crackling Pistil / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "5 - Silver Tail To Saturn Ring With Green Peony / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 11,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "5 - Silver Tail To Saturn Ring With Green Peony / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "5 - Smoke Azul 4/1 - 25 tubos [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 37,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "5 - Smoke Azul 4/1 - 25 tubos [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "5 - Torta Malta / Gold Palm Comet - Blue Star",
+      "disponivel": true,
+      "quantidade": 308,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Brocade Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Brocade Tail To Brocade Ring / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 9,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Brocade Tail To Brocade Ring / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "6 - Brocade To Green Chry / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 2,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Brocade To Green Chry / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "6 - Purple To Silve Strobe / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 2,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Purple To Silve Strobe / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "6 - Red to Blue to White Strobe Mine",
+      "disponivel": true,
+      "quantidade": 27,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Silver Wave To Red Peony / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Silver Wave To Red Peony / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "6 - Smoke Roxa 4/1 - 25 tubos [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 42,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "6 - Smoke Roxa 4/1 - 25 tubos [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "6 - Torta Malta / Gold Palm Comet - Red Star",
+      "disponivel": true,
+      "quantidade": 125,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "7 - Brocade / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "7 - Brocade / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "7 - Brocade / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "7 - Brocade / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "7 - Brocade Red Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "7 - Ghost Shel / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 8,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "7 - Ghost Shel / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "7 - Green/Blue/Red Mine",
+      "disponivel": true,
+      "quantidade": 34,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "7 - Silver Palm Tree Crackling Pistil / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "7 - Silver Palm Tree Crackling Pistil / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "7 - Torta Malta / Gold Palm - Pink Star",
+      "disponivel": true,
+      "quantidade": 228,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Brocade Blue Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Brocade Red",
+      "disponivel": true,
+      "quantidade": 36,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Flower Brocade / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Flower Brocade / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "8 - Red Palm Crossete / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Red Palm Crossete / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "8 - Red Wave Crossette / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 8,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Red Wave Crossette / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "8 - Torta Malta / Gold Palm Comet - Green Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Yellow To Green Peony / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "8 - Yellow To Green Peony / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "9 - Brocade Blue",
+      "disponivel": true,
+      "quantidade": 33,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "9 - Brocade Pink Mine",
+      "disponivel": true,
+      "quantidade": 400,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "9 - Brocade Tail To Spinner Flower White Blue Pistil / 6\" | 9/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 6,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "9 - Brocade Tail To Spinner Flower White Blue Pistil / 6\" | 9/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "9 - Brocade To Green / 3\" | 72/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 5,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "9 - Brocade To Green / 3\" | 72/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "9 - Ghost Face / 5\" | 24/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 4,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "9 - Ghost Face / 5\" | 24/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "9 - Gold Wave With Green To Silver / 4\" | 36/1 [ CAIXA ]",
+      "disponivel": true,
+      "quantidade": 3,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "9 - Gold Wave With Green To Silver / 4\" | 36/1 [ UNIDADE ]",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Un"
+    },
+    {
+      "nome": "9 - Torta Malta / Gold Strobe Tail - Blue Star",
+      "disponivel": false,
+      "quantidade": 0,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "Smoke Azul 1/1 - [Cascata] - 100 tubos",
+      "disponivel": true,
+      "quantidade": 98,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "Smoke Azul 1/1 - [Explosão] - 100 tubos",
+      "disponivel": true,
+      "quantidade": 49,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "Smoke Rosa 1/1 - [Cascata] - 100 tubos",
+      "disponivel": true,
+      "quantidade": 90,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "Smoke Rosa 1/1 - [Explosão] - 100 tubos",
+      "disponivel": true,
+      "quantidade": 49,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "Smoke Roxa 1/1 - [Cascata] - 100 tubos",
+      "disponivel": true,
+      "quantidade": 91,
+      "unidade": "Cx"
+    },
+    {
+      "nome": "Smoke Roxa 1/1 - [Explosão] - 100 tubos",
+      "disponivel": true,
+      "quantidade": 49,
+      "unidade": "Cx"
+    }
+  ]
+}

--- a/src/utils/catalogoCache.js
+++ b/src/utils/catalogoCache.js
@@ -1,22 +1,58 @@
-﻿const TinyClient = require('./tinyClient');
+﻿// src/utils/catalogoCache.js
+
+const fs = require('fs');
+const path = require('path');
+const TinyClient = require('./tinyClient');
+
+const CACHE_FILE = path.join(__dirname, '../data/catalogo-cache.json');
+const CACHE_TTL = 60 * 60 * 1000; // 60 minutos
 
 let _cache = null;
 let _lastUpdate = null;
-const CACHE_TTL = 10 * 60 * 1000; // 10 minutos
 
-async function getCatalogoBot() {
-    const agora = Date.now();
+// ─── Persistência em disco ────────────────────────────────────────────────────
 
-    if (_cache && _lastUpdate && (agora - _lastUpdate) < CACHE_TTL) {
-        console.log('[CatálogoCache] Retornando cache existente');
-        return _cache;
+function salvarCacheEmDisco(produtos) {
+    try {
+        const payload = {atualizadoEm: Date.now(), produtos};
+        fs.writeFileSync(CACHE_FILE, JSON.stringify(payload));
+        console.log(`[CatálogoCache] Cache salvo em disco — ${produtos.length} produtos`);
+    } catch (err) {
+        console.error('[CatálogoCache] Erro ao salvar cache em disco:', err.message);
     }
+}
 
+function carregarCacheDoisco() {
+    try {
+        if (!fs.existsSync(CACHE_FILE)) return false;
+        const raw = fs.readFileSync(CACHE_FILE, 'utf8');
+        const payload = JSON.parse(raw);
+        const idade = Date.now() - payload.atualizadoEm;
+
+        _cache = payload.produtos;
+        _lastUpdate = payload.atualizadoEm;
+
+        if (idade > CACHE_TTL) {
+            console.log('[CatálogoCache] Cache em disco expirado — será renovado em background');
+        } else {
+            const minutos = Math.floor(idade / 60000);
+            console.log(`[CatálogoCache] Cache carregado do disco — ${_cache.length} produtos (${minutos}min atrás)`);
+        }
+        return true;
+    } catch (err) {
+        console.error('[CatálogoCache] Erro ao carregar cache do disco:', err.message);
+        return false;
+    }
+}
+
+// ─── Busca no Tiny ────────────────────────────────────────────────────────────
+
+async function buscarDoTiny() {
     console.log('[CatálogoCache] Buscando catálogo atualizado no Tiny...');
     const client = new TinyClient(process.env.TINY_API_TOKEN);
     const produtos = await client.pesquisarProdutosComEstoque();
 
-    _cache = produtos.map(p => ({
+    const catalogo = produtos.map(p => ({
         codigo: p.sku,
         nome: p.nome,
         categoria: p.categoria,
@@ -25,18 +61,64 @@ async function getCatalogoBot() {
         unidade: p.unidade || 'UN'
     }));
 
-    _lastUpdate = agora;
-    console.log(`[CatálogoCache] Cache atualizado — ${_cache.length} produtos`);
-    return _cache;
+    _cache = catalogo;
+    _lastUpdate = Date.now();
+    salvarCacheEmDisco(catalogo);
+    console.log(`[CatálogoCache] Cache atualizado — ${catalogo.length} produtos`);
+    return catalogo;
+}
+
+// ─── Interface pública ────────────────────────────────────────────────────────
+
+async function getCatalogoBot() {
+    // Cache em memória válido
+    if (_cache && _lastUpdate && (Date.now() - _lastUpdate) < CACHE_TTL) {
+        console.log('[CatálogoCache] Retornando cache em memória');
+        return _cache;
+    }
+
+    // Cache em memória expirado mas existe — retorna dados antigos e renova em background
+    if (_cache) {
+        console.log('[CatálogoCache] Cache expirado — retornando dados antigos e renovando em background');
+        buscarDoTiny().catch(err =>
+            console.error('[CatálogoCache] Erro na renovação em background:', err.message)
+        );
+        return _cache;
+    }
+
+    // Sem cache em memória — busca síncrona (só na primeira chamada após restart sem disco)
+    return await buscarDoTiny();
 }
 
 function aquecerCache() {
-    console.log('[CatálogoCache] Aquecendo cache em background...');
-    setTimeout(() => {
-        getCatalogoBot()
-            .then(c => console.log(`[CatálogoCache] Cache aquecido — ${c.length} produtos`))
-            .catch(err => console.error('[CatálogoCache] Falha ao aquecer cache:', err.message));
-    }, 5000); // aguarda 5s após o servidor subir
+    console.log('[CatálogoCache] Inicializando cache...');
+
+    const carregouDoDisco = carregarCacheDoisco();
+
+    if (carregouDoDisco) {
+        const idade = Date.now() - _lastUpdate;
+        if (idade > CACHE_TTL) {
+            setTimeout(() => {
+                buscarDoTiny().catch(err =>
+                    console.error('[CatálogoCache] Erro ao renovar cache expirado:', err.message)
+                );
+            }, 5000);
+        }
+    } else {
+        setTimeout(() => {
+            buscarDoTiny().catch(err =>
+                console.error('[CatálogoCache] Erro ao aquecer cache:', err.message)
+            );
+        }, 5000);
+    }
+
+    // Renovação automática a cada 60 minutos
+    setInterval(() => {
+        console.log('[CatálogoCache] Renovação automática agendada...');
+        buscarDoTiny().catch(err =>
+            console.error('[CatálogoCache] Erro na renovação automática:', err.message)
+        );
+    }, CACHE_TTL);
 }
 
 module.exports = {getCatalogoBot, aquecerCache};

--- a/src/utils/catalogoCache.js
+++ b/src/utils/catalogoCache.js
@@ -22,7 +22,7 @@ function salvarCacheEmDisco(produtos) {
     }
 }
 
-function carregarCacheDoisco() {
+function carregarCacheDoDisco() {
     try {
         if (!fs.existsSync(CACHE_FILE)) return false;
         const raw = fs.readFileSync(CACHE_FILE, 'utf8');
@@ -93,7 +93,7 @@ async function getCatalogoBot() {
 function aquecerCache() {
     console.log('[CatálogoCache] Inicializando cache...');
 
-    const carregouDoDisco = carregarCacheDoisco();
+    const carregouDoDisco = carregarCacheDoDisco();
 
     if (carregouDoDisco) {
         const idade = Date.now() - _lastUpdate;


### PR DESCRIPTION
## [Feature] Cache persistente do catálogo com TTL de 60min e renovação automática

**Ref:** #9

---

## Problema

O cache do catálogo de produtos Tiny era mantido apenas em memória com
TTL de 10 minutos. Após cada restart do servidor ou expiração do cache,
a primeira chamada ao `/bot/catalogo` bloqueava por 15-20 minutos
aguardando a busca completa do Tiny — inaceitável para o bot em produção.

---

## Solução

- `catalogoCache.js` reescrito com três camadas de cache:
  1. **Memória** — retorno instantâneo enquanto TTL válido
  2. **Disco** (`src/data/catalogo-cache.json`) — carregado no startup,
     elimina espera após restart
  3. **Background** — cache expirado retorna dados antigos imediatamente
     e renova em background sem bloquear o bot
- TTL aumentado de 10 para 60 minutos
- `setInterval` renova o cache automaticamente a cada 60 minutos
- `catalogo-cache.json` adicionado ao `.gitignore` — persiste apenas
  no volume Fly.io, não no repositório

---

## Checklist

- [x] Servidor reiniciado carrega cache do disco em menos de 1 segundo
- [x] Segunda chamada retorna instantaneamente do cache em memória
- [x] Cache renovado automaticamente a cada 60 minutos em background
- [x] `src/data/catalogo-cache.json` no `.gitignore`
- [x] Após deploy: log confirma `Cache carregado do disco` no startup

---

Closes #9