### PR TITLE
## [Feature] Rota pública /bot/catalogo.txt para consumo da IA

### DIFF
--- a/src/routes/bot.js
+++ b/src/routes/bot.js
@@ -20,4 +20,40 @@ router.get('/catalogo', async (req, res) => {
     }
 });
 
+/**
+ * GET /bot/catalogo.txt
+ * Retorna catálogo formatado em texto simples para consumo da IA.
+ * SEM autenticação — URL pública para upload em plataformas de IA.
+ */
+router.get('/catalogo.txt', async (req, res) => {
+    try {
+        const produtos = await getCatalogoBot();
+
+        // Agrupa por categoria
+        const categorias = {};
+        for (const p of produtos) {
+            if (!categorias[p.categoria]) categorias[p.categoria] = [];
+            categorias[p.categoria].push(p);
+        }
+
+        let texto = `CATÁLOGO DE PRODUTOS — MAGIC EFFECTS BRASIL\n`;
+        texto += `Atualizado em: ${new Date().toLocaleDateString('pt-BR')}\n`;
+        texto += `Total: ${produtos.length} produtos\n\n`;
+
+        for (const [cat, itens] of Object.entries(categorias).sort()) {
+            texto += `== ${cat.toUpperCase()} ==\n`;
+            for (const p of itens) {
+                const status = p.disponivel ? `Disponível (${p.quantidade} ${p.unidade})` : 'Indisponível';
+                texto += `- ${p.nome} | Cód: ${p.codigo} | ${status}\n`;
+            }
+            texto += '\n';
+        }
+
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.send(texto);
+    } catch (err) {
+        res.status(500).send(`Erro ao gerar catálogo: ${err.message}`);
+    }
+});
+
 module.exports = router;


### PR DESCRIPTION
## [Feature] Rota pública /bot/catalogo.txt para consumo da IA

**Ref:** #7

---

## Problema

A rota `/bot/catalogo` existente retorna JSON e exige header `x-api-key`.
Plataformas de IA como o SleekFlow não conseguem consumir essa rota como
fonte de conhecimento — elas precisam de uma URL pública que retorne
texto simples e legível.

---

## Solução

- Adicionada rota `GET /bot/catalogo.txt` em `src/routes/bot.js`
- Rota pública — sem autenticação
- Retorna `text/plain; charset=utf-8`
- Catálogo agrupado por categoria com nome, código, disponibilidade
  e quantidade de cada produto
- Reutiliza o cache existente do `catalogoCache.js` — nenhuma chamada
  adicional ao Tiny ERP

---

## Checklist

- [x] `GET /bot/catalogo.txt` retorna `200` sem header adicional
- [x] `Content-Type: text/plain` confirmado
- [x] Conteúdo legível agrupado por categoria no navegador
- [x] Reutiliza cache — sem chamada ao Tiny
- [x] Após deploy: URL indexada com sucesso como fonte no SleekFlow

---

Closes #7