### PR TITLE
[Feature] Parser de pedido + Validação contra catálogo + CRUD

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ const apiRoutes = require('./routes/api');
 const equipamentosRoutes = require('./routes/equipamentos');
 const botRoutes = require('./routes/bot');
 const catalogoRoutes = require('./routes/catalogo');
+const pedidosRoutes = require('./routes/pedidos');
 
 function createApp() {
     const app = express();
@@ -54,6 +55,7 @@ function createApp() {
 
     // ─── Rotas API ───────────────────────────────────────────────────────────────
     app.use('/api/equipamentos', equipamentosRoutes);
+    app.use('/api/pedidos', pedidosRoutes);
     app.use('/api', apiRoutes);
     app.use('/api/catalogo', catalogoRoutes);
 

--- a/src/routes/pedidos.js
+++ b/src/routes/pedidos.js
@@ -1,0 +1,172 @@
+﻿const express = require('express');
+const path = require('path');
+const {readJSON, writeJSONAtomic, listJSON} = require('../utils/storage');
+const {parsearTexto} = require('../utils/parserPedido');
+const {validarItens} = require('../utils/validadorCatalogo');
+
+const router = express.Router();
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const PEDIDOS_DIR = path.join(DATA_DIR, 'pedidos');
+const CONFIG_FILE = path.join(DATA_DIR, 'config-pedidos.json');
+
+// ---- Helpers ----
+
+function lerConfig() {
+    return readJSON(CONFIG_FILE, {proximo_numero: 1});
+}
+
+function proximoNumero() {
+    const config = lerConfig();
+    const num = config.proximo_numero || 1;
+    const ano = new Date().getFullYear();
+    const numero = `PED-${ano}-${String(num).padStart(3, '0')}`;
+    config.proximo_numero = num + 1;
+    writeJSONAtomic(CONFIG_FILE, config);
+    return numero;
+}
+
+function pedidoPath(numero) {
+    return path.join(PEDIDOS_DIR, `${numero}.json`);
+}
+
+// ===================== PARSE =====================
+
+// POST /api/pedidos/parse — texto → rascunho com 3 baldes
+router.post('/parse', (req, res) => {
+    try {
+        const {texto} = req.body;
+        if (!texto || typeof texto !== 'string') {
+            return res.status(400).json({success: false, error: 'Campo "texto" é obrigatório'});
+        }
+
+        const itensParsed = parsearTexto(texto);
+        if (itensParsed.length === 0) {
+            return res.status(400).json({success: false, error: 'Nenhum item encontrado no texto'});
+        }
+
+        const resultado = validarItens(itensParsed);
+        res.json({success: true, data: resultado});
+    } catch (err) {
+        res.status(500).json({success: false, error: err.message});
+    }
+});
+
+// ===================== CRUD =====================
+
+// POST /api/pedidos — salva rascunho
+router.post('/', (req, res) => {
+    try {
+        const {cliente, itens, observacoes} = req.body;
+        if (!itens || !Array.isArray(itens) || itens.length === 0) {
+            return res.status(400).json({success: false, error: 'Pedido precisa de pelo menos um item'});
+        }
+
+        const numero = proximoNumero();
+        const pedido = {
+            numero,
+            cliente: (cliente || '').trim(),
+            tipo: 'pedido',
+            status: 'rascunho',
+            data_emissao: new Date().toISOString(),
+            data_atualizacao: new Date().toISOString(),
+            itens,
+            movimentos: [],
+            observacoes: (observacoes || '').trim()
+        };
+
+        writeJSONAtomic(pedidoPath(numero), pedido);
+        res.json({success: true, data: pedido});
+    } catch (err) {
+        res.status(500).json({success: false, error: err.message});
+    }
+});
+
+// GET /api/pedidos — lista (com filtro opcional de/até)
+router.get('/', (req, res) => {
+    try {
+        const {de, ate} = req.query;
+        const arquivos = listJSON(PEDIDOS_DIR);
+        let pedidos = arquivos.map(f => readJSON(path.join(PEDIDOS_DIR, f), null)).filter(Boolean);
+
+        // Filtro por período
+        if (de) pedidos = pedidos.filter(p => p.data_emissao >= de);
+        if (ate) pedidos = pedidos.filter(p => p.data_emissao <= ate + 'T23:59:59.999Z');
+
+        // Ordena do mais recente pro mais antigo
+        pedidos.sort((a, b) => (b.data_emissao || '').localeCompare(a.data_emissao || ''));
+
+        // Retorna resumo (sem itens/movimentos, pra não pesar)
+        const lista = pedidos.map(p => ({
+            numero: p.numero,
+            cliente: p.cliente,
+            status: p.status,
+            data_emissao: p.data_emissao,
+            total_itens: (p.itens || []).length,
+            total_valor: (p.itens || []).reduce((s, i) => s + (i.qtd_un || 0) * (i.preco_unit || 0), 0)
+        }));
+
+        res.json({success: true, data: lista, total: lista.length});
+    } catch (err) {
+        res.status(500).json({success: false, error: err.message});
+    }
+});
+
+// GET /api/pedidos/:numero — obtém um pedido
+router.get('/:numero', (req, res) => {
+    try {
+        const pedido = readJSON(pedidoPath(req.params.numero), null);
+        if (!pedido) return res.status(404).json({success: false, error: 'Pedido não encontrado'});
+        res.json({success: true, data: pedido});
+    } catch (err) {
+        res.status(500).json({success: false, error: err.message});
+    }
+});
+
+// PUT /api/pedidos/:numero — edita (só rascunho)
+router.put('/:numero', (req, res) => {
+    try {
+        const pedido = readJSON(pedidoPath(req.params.numero), null);
+        if (!pedido) return res.status(404).json({success: false, error: 'Pedido não encontrado'});
+        if (pedido.status !== 'rascunho') {
+            return res.status(400).json({
+                success: false,
+                error: `Pedido com status "${pedido.status}" não pode ser editado — reverta primeiro`
+            });
+        }
+
+        const {cliente, itens, observacoes} = req.body;
+        if (cliente !== undefined) pedido.cliente = cliente.trim();
+        if (itens !== undefined) pedido.itens = itens;
+        if (observacoes !== undefined) pedido.observacoes = observacoes.trim();
+        pedido.data_atualizacao = new Date().toISOString();
+
+        writeJSONAtomic(pedidoPath(req.params.numero), pedido);
+        res.json({success: true, data: pedido});
+    } catch (err) {
+        res.status(500).json({success: false, error: err.message});
+    }
+});
+
+// DELETE /api/pedidos/:numero — exclui (só rascunho)
+router.delete('/:numero', (req, res) => {
+    try {
+        const fs = require('fs');
+        const filePath = pedidoPath(req.params.numero);
+        const pedido = readJSON(filePath, null);
+        if (!pedido) return res.status(404).json({success: false, error: 'Pedido não encontrado'});
+        if (pedido.status !== 'rascunho') {
+            return res.status(400).json({
+                success: false,
+                error: `Pedido com status "${pedido.status}" não pode ser excluído — reverta e depois exclua`
+            });
+        }
+
+        fs.unlinkSync(filePath);
+        res.json({success: true, data: pedido});
+    } catch (err) {
+        res.status(500).json({success: false, error: err.message});
+    }
+});
+
+module.exports = router;

--- a/src/utils/multiplicador.js
+++ b/src/utils/multiplicador.js
@@ -1,0 +1,33 @@
+﻿const fs = require('fs');
+const path = require('path');
+
+const MULT_FILE = path.join(__dirname, '..', '..', 'multiplicadores.json');
+
+function carregarMultiplicadores() {
+    try {
+        return JSON.parse(fs.readFileSync(MULT_FILE, 'utf8').replace(/^\uFEFF/, ''));
+    } catch (e) {
+        console.error('[Multiplicador] Erro ao ler multiplicadores.json:', e.message);
+        return {classes: {}, overrides: {}};
+    }
+}
+
+function obterFator(codigo) {
+    if (!codigo) return 1;
+    const mult = carregarMultiplicadores();
+
+    if (mult.overrides && mult.overrides[codigo] !== undefined) {
+        return mult.overrides[codigo] || 1;
+    }
+
+    const prefixos = Object.keys(mult.classes || {}).sort((a, b) => b.length - a.length);
+    for (const prefixo of prefixos) {
+        if (codigo.toUpperCase().startsWith(prefixo.toUpperCase())) {
+            return mult.classes[prefixo].por_caixa || 1;
+        }
+    }
+
+    return 1;
+}
+
+module.exports = {obterFator, carregarMultiplicadores};

--- a/src/utils/parserPedido.js
+++ b/src/utils/parserPedido.js
@@ -1,0 +1,51 @@
+﻿// Quebra texto padronizado em linhas de item estruturadas.
+// Formato por linha: CÓDIGO ; QTD ; UNIDADE ; PREÇO_UNIT
+// Linhas com # = cabeçalho de seção (ignorado). Linhas vazias = ignoradas.
+
+function parsearTexto(texto) {
+    if (!texto || typeof texto !== 'string') return [];
+
+    const linhas = texto.split('\n').map(l => l.trim()).filter(Boolean);
+    const itens = [];
+
+    for (const linha of linhas) {
+        // Cabeçalho de seção
+        if (linha.startsWith('#')) continue;
+
+        // Comentário
+        if (linha.startsWith('//')) continue;
+
+        const partes = linha.split(';').map(p => p.trim());
+
+        if (partes.length < 2) {
+            // Linha mal formatada — registra como erro
+            itens.push({
+                linha_original: linha,
+                codigo: partes[0] || '',
+                qtd_entrada: 0,
+                unidade_entrada: 'UN',
+                preco_unit: 0,
+                erro_parse: 'Formato inválido — esperado: CÓDIGO ; QTD ; UNIDADE ; PREÇO'
+            });
+            continue;
+        }
+
+        const codigo = partes[0] || '';
+        const qtd = parseFloat((partes[1] || '0').replace(/\./g, '').replace(',', '.')) || 0;
+        const unidade = (partes[2] || 'UN').toUpperCase().trim();
+        const preco = parseFloat((partes[3] || '0').replace(/\./g, '').replace(',', '.')) || 0;
+
+        itens.push({
+            linha_original: linha,
+            codigo,
+            qtd_entrada: qtd,
+            unidade_entrada: unidade,
+            preco_unit: preco,
+            erro_parse: null
+        });
+    }
+
+    return itens;
+}
+
+module.exports = { parsearTexto };

--- a/src/utils/validadorCatalogo.js
+++ b/src/utils/validadorCatalogo.js
@@ -1,0 +1,114 @@
+﻿const path = require('path');
+const {readJSON} = require('./storage');
+const {obterFator} = require('./multiplicador');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const PRODUTOS_FILE = path.join(DATA_DIR, 'produtos.json');
+const CACHE_FILE = path.join(DATA_DIR, 'catalogo-cache.json');
+
+function carregarCatalogo() {
+    const nosso = readJSON(PRODUTOS_FILE, {produtos: []});
+    const cache = readJSON(CACHE_FILE, {produtos: []});
+    // Nosso store tem prioridade; merge pelo código
+    const mapa = new Map();
+    for (const p of (cache.produtos || [])) {
+        if (p.codigo) mapa.set(p.codigo.toUpperCase(), p);
+    }
+    for (const p of (nosso.produtos || [])) {
+        if (p.codigo) mapa.set(p.codigo.toUpperCase(), p);
+    }
+    return mapa;
+}
+
+// Busca exata → verde; substring no código/nome → amarelo; nada → vermelho
+function validarItem(item, catalogo) {
+    const codigo = (item.codigo || '').trim();
+    const codigoUpper = codigo.toUpperCase();
+
+    // Erro de parse — já é vermelho
+    if (item.erro_parse) {
+        return {
+            ...item,
+            status: 'vermelho',
+            motivo: item.erro_parse,
+            descricao: '',
+            candidatos: []
+        };
+    }
+
+    // Match exato
+    const exato = catalogo.get(codigoUpper);
+    if (exato) {
+        return montarResultado(item, exato, 'verde', null);
+    }
+
+    // Fuzzy: substring no código ou no nome
+    const candidatos = [];
+    for (const [key, prod] of catalogo) {
+        const nomeUpper = (prod.nome || '').toUpperCase();
+        if (key.includes(codigoUpper) || codigoUpper.includes(key) ||
+            nomeUpper.includes(codigoUpper)) {
+            candidatos.push({codigo: prod.codigo, nome: prod.nome});
+            if (candidatos.length >= 5) break;
+        }
+    }
+
+    if (candidatos.length === 1) {
+        // Um só candidato — resolve como verde
+        const prod = catalogo.get(candidatos[0].codigo.toUpperCase());
+        return montarResultado(item, prod, 'verde', null);
+    }
+
+    if (candidatos.length > 1) {
+        return {
+            ...item,
+            status: 'amarelo',
+            motivo: `${candidatos.length} candidatos encontrados`,
+            descricao: '',
+            candidatos
+        };
+    }
+
+    // Nada
+    return {
+        ...item,
+        status: 'vermelho',
+        motivo: 'Código não encontrado no catálogo',
+        descricao: '',
+        candidatos: []
+    };
+}
+
+function montarResultado(item, produto, status, motivo) {
+    const fator = item.unidade_entrada === 'CX'
+        ? obterFator(produto.codigo)
+        : 1;
+    const qtd_un = item.qtd_entrada * fator;
+
+    return {
+        codigo: produto.codigo,
+        descricao: produto.nome || '',
+        qtd_entrada: item.qtd_entrada,
+        unidade_entrada: item.unidade_entrada,
+        fator,
+        qtd_un,
+        preco_unit: item.preco_unit || 0,
+        status,
+        motivo,
+        candidatos: [],
+        linha_original: item.linha_original
+    };
+}
+
+function validarItens(itensParsed) {
+    const catalogo = carregarCatalogo();
+    const resultados = itensParsed.map(item => validarItem(item, catalogo));
+    const resumo = {
+        verdes: resultados.filter(r => r.status === 'verde').length,
+        amarelos: resultados.filter(r => r.status === 'amarelo').length,
+        vermelhos: resultados.filter(r => r.status === 'vermelho').length
+    };
+    return {itens: resultados, resumo};
+}
+
+module.exports = {validarItens};


### PR DESCRIPTION
## O que foi feito
Parser que transforma texto padronizado (`CÓDIGO ; QTD ; UNIDADE ; PREÇO`) em rascunho estruturado, com cada item classificado em verde (exato), amarelo (fuzzy/ambíguo) ou vermelho (não encontrado). Multiplicador caixa→UN via longest-prefix match (`multiplicadores.json`). CRUD completo de pedidos em `data/pedidos/PED-YYYY-NNN.json` com escrita atômica.

---

## Checklist
- [x] O código compila sem erros
- [x] `POST /api/pedidos/parse` classifica itens nos 3 baldes
- [x] Multiplicador correto: `MFSSS-001 ; 5 ; CX` → `fator: 400`, `qtd_un: 2000`
- [x] CRUD funcional: salva, lista, obtém, edita (só rascunho), exclui (só rascunho)
- [x] Preço com vírgula brasileira aceito (`10,00` → `10.00`)
- [x] App sobe sem erro; rotas existentes intactas
- [x] Nenhum console.log ou código de debug esquecido

---

Closes #19